### PR TITLE
Add Selenium Grid 4 with video recording and Allure integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ CLAUDE.md
 .allure/
 data_mysql/
 data_postgres/
-gate-simulator/node_modules
+gate-simulator/node_modulesvideos/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ All UI and DB tests run against both **Payment** and **Credit** flows.
 | DB Access | Commons-DbUtils | 1.8.1 |
 | Serialization | Gson | 2.13.2 |
 | Code Gen | Lombok | 9.2.0 (plugin) |
+| Remote Browser | Selenium Grid 4 | standalone-chromium |
 | Infrastructure | Docker Compose | v2+ |
 
 ---
@@ -140,7 +141,7 @@ cd demo-alfabank-test-framework
 docker-compose up -d --build
 ```
 
-This spins up the gate simulator (port 9999), MySQL (port 3306), and PostgreSQL (port 5432).
+This spins up the gate simulator (port 9999), MySQL (port 3306), PostgreSQL (port 5432), Selenium Grid (port 4444), and noVNC viewer (port 7900).
 
 **3. Start the SUT**
 
@@ -168,6 +169,11 @@ The application will be available at `http://localhost:8080`.
 
 # Headless mode (CI)
 ./gradlew test -Dselenide.headless=true -Ddb.url=jdbc:mysql://localhost:3306/app
+
+# Through Selenium Grid (browser runs in Docker container)
+./gradlew test -Ddb.url=jdbc:mysql://localhost:3306/app \
+  -Dselenide.remote=http://localhost:4444/wd/hub \
+  -Dsut.url=http://host.docker.internal:8080/
 ```
 
 **5. View Allure report**
@@ -279,6 +285,22 @@ The gate simulator is a minimal Express.js service that mimics the bank payment 
 | Any other | HTTP 400 |
 
 It listens on port **9999** and handles both `/payment` and `/credit` endpoints.
+
+---
+
+## Selenium Grid
+
+The framework supports remote browser execution via [Selenium Grid 4](https://www.selenium.dev/documentation/grid/) Standalone. When enabled, tests run inside a Docker container with Chromium — no local browser installation required.
+
+| Service | Port | Purpose |
+|:--------|:-----|:--------|
+| Selenium Grid | 4444 | WebDriver endpoint |
+| noVNC | 7900 | Live browser view — open `http://localhost:7900` |
+| Video Recorder | — | Records each session, attaches to Allure on failure |
+
+**Video on failure**: `VideoAttachExtension` (JUnit `TestWatcher`) automatically attaches the recorded video to the Allure report when a test fails. Successful test recordings are deleted to save disk space.
+
+Pass `-Dselenide.remote=http://localhost:4444/wd/hub` to enable Grid mode. Without this flag, tests use the local browser.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 test {
     useJUnitPlatform()
     systemProperty 'selenide.headless', System.getProperty('selenide.headless')
+    systemProperty 'selenide.remote', System.getProperty('selenide.remote')
     systemProperty 'db.url', System.getProperty('db.url')
     systemProperty 'db.user', System.getProperty('db.user', "app")
     systemProperty 'db.password', System.getProperty('db.password', "pass")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,16 @@ services:
       - SE_SCREEN_WIDTH=1920
       - SE_SCREEN_HEIGHT=1080
       - SE_VNC_NO_PASSWORD=1
+
+  selenium-video:
+    image: selenium/video:latest
+    depends_on:
+      - selenium
+    volumes:
+      - ./videos:/videos
+    environment:
+      - DISPLAY_CONTAINER_NAME=selenium
+      - SE_VIDEO_RECORD_STANDALONE=true
+      - SE_VIDEO_FILE_NAME=auto
+      - SE_VIDEO_CODEC=libx264
+      - SE_VIDEO_MOVFLAGS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,14 @@ services:
       - MYSQL_DATABASE=app
       - MYSQL_USER=app
       - MYSQL_PASSWORD=pass
+
+  selenium:
+    image: seleniarm/standalone-chromium:latest
+    ports:
+      - '4444:4444'
+      - '7900:7900'
+    shm_size: '2gb'
+    environment:
+      - SE_SCREEN_WIDTH=1920
+      - SE_SCREEN_HEIGHT=1080
+      - SE_VNC_NO_PASSWORD=1

--- a/docs/issues-english.md
+++ b/docs/issues-english.md
@@ -1,0 +1,285 @@
+# GitHub Issues — English Translations
+
+Copy each issue below into the corresponding GitHub issue.
+Format: Title + Body (markdown).
+
+---
+
+## Issue #1
+
+**Title:** Spelling error in tour destination name
+
+**Body:**
+
+## Description
+
+The tour destination name on the landing page contains a spelling error.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Observe the tour card heading
+
+## Actual result
+
+Tour destination displayed as **"Марракэш"** (with "э")
+
+## Expected result
+
+Tour destination should be **"Марракеш"** (with "е") — the correct Russian spelling of Marrakesh.
+
+## Screenshot
+
+![Landing page with spelling error](docs/ui-landing-page.png)
+
+---
+
+## Issue #2
+
+**Title:** Error and success notifications appear simultaneously when paying with a DECLINED card
+
+**Body:**
+
+## Description
+
+When submitting a payment with a DECLINED card (`4444 4444 4444 4442`), both the success notification ("Операция одобрена Банком") and the error notification ("Банк отказал в проведении операции") are displayed at the same time.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy)
+3. Fill the form with DECLINED card number: `4444 4444 4444 4442`, valid month/year/holder/CVC
+4. Click "Продолжить" (Continue)
+5. Wait for the notification(s)
+
+## Actual result
+
+Both success and error notification pop-ups appear simultaneously.
+
+## Expected result
+
+Only the error notification should appear: "Ошибка! Банк отказал в проведении операции."
+
+---
+
+## Issue #3
+
+**Title:** `credit_id` is not populated in `order_entity` table for credit transactions
+
+**Body:**
+
+## Description
+
+When a credit transaction is completed successfully, the `credit_id` column in the `order_entity` table remains `NULL`. The `payment_id` is populated correctly for debit payments, but the equivalent field for credit flow is missing.
+
+## Steps to reproduce
+
+1. Start the SUT and infrastructure
+2. Click "Купить в кредит" (Buy on credit)
+3. Fill the form with APPROVED card: `4444 4444 4444 4441`, valid data
+4. Click "Продолжить" (Continue)
+5. Wait for the success notification
+6. Query the database: `SELECT * FROM order_entity;`
+
+## Actual result
+
+`credit_id` is `NULL` in the `order_entity` record.
+
+## Expected result
+
+`credit_id` should contain the ID linking to the corresponding `credit_request_entity` record.
+
+---
+
+## Issue #4
+
+**Title:** "Owner" field accepts invalid characters (special characters, digits)
+
+**Body:**
+
+## Description
+
+The "Владелец" (Owner) field accepts input containing special characters (`!@#$%^&*()`), digits, and other non-alphabetic characters without showing a validation error.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy) or "Купить в кредит" (Buy on credit)
+3. Fill the card number, month, year, and CVC with valid values
+4. Enter `123!@#$%` in the "Владелец" (Owner) field
+5. Click "Продолжить" (Continue)
+
+## Actual result
+
+The form is submitted without a validation error under the Owner field.
+
+## Expected result
+
+A validation error should appear under the Owner field indicating that only Latin alphabetic characters are allowed.
+
+---
+
+## Issue #5
+
+**Title:** "Owner" field accepts Cyrillic characters
+
+**Body:**
+
+## Description
+
+The "Владелец" (Owner) field accepts Cyrillic characters. Since card holder names are printed in Latin characters, Cyrillic input should be rejected.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy)
+3. Fill all fields with valid data, but enter `Иванов Иван` in the Owner field
+4. Click "Продолжить" (Continue)
+
+## Actual result
+
+The form is submitted without a validation error. The request is sent to the bank with Cyrillic characters in the holder name.
+
+## Expected result
+
+A validation error should appear under the Owner field indicating that only Latin characters are allowed.
+
+---
+
+## Issue #6
+
+**Title:** Validation error for empty CVC/CVV field appears under the "Owner" field instead
+
+**Body:**
+
+## Description
+
+When the CVC/CVV field is left empty and the form is submitted, the validation error message appears under the "Владелец" (Owner) field instead of under the CVC/CVV field.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy)
+3. Fill all fields with valid data **except** CVC/CVV — leave it empty
+4. Click "Продолжить" (Continue)
+
+## Actual result
+
+The validation error "Поле обязательно для заполнения" appears under the **Owner** field.
+
+## Expected result
+
+The validation error should appear under the **CVC/CVV** field.
+
+---
+
+## Issue #7
+
+**Title:** Incorrect transaction status in database and wrong notification for DECLINED card payment
+
+**Body:**
+
+## Description
+
+When paying with a DECLINED card (`4444 4444 4444 4442`), the database records the transaction with an APPROVED status, and/or the UI notification does not match the actual DB state.
+
+## Steps to reproduce
+
+1. Start the SUT with a clean database
+2. Click "Купить" (Buy)
+3. Fill the form with DECLINED card: `4444 4444 4444 4442`, valid data
+4. Click "Продолжить" (Continue)
+5. Observe the notification
+6. Query: `SELECT status FROM payment_entity;`
+
+## Actual result
+
+The `payment_entity.status` shows `APPROVED` and/or the notification shows success instead of error. The UI state and DB state are inconsistent.
+
+## Expected result
+
+`payment_entity.status` should be `DECLINED`, and the UI should display the error notification.
+
+---
+
+## Issue #8
+
+**Title:** Incorrect transaction status recorded in database for credit flow
+
+**Body:**
+
+## Description
+
+When requesting credit with a DECLINED card (`4444 4444 4444 4442`), the `credit_request_entity` table records the status incorrectly (e.g., `APPROVED` instead of `DECLINED`).
+
+## Steps to reproduce
+
+1. Start the SUT with a clean database
+2. Click "Купить в кредит" (Buy on credit)
+3. Fill the form with DECLINED card: `4444 4444 4444 4442`, valid data
+4. Click "Продолжить" (Continue)
+5. Wait for the notification
+6. Query: `SELECT status FROM credit_request_entity;`
+
+## Actual result
+
+`credit_request_entity.status` = `APPROVED`
+
+## Expected result
+
+`credit_request_entity.status` = `DECLINED`
+
+---
+
+## Issue #9
+
+**Title:** Missing validation error for invalid month value (e.g., "00")
+
+**Body:**
+
+## Description
+
+When entering `00` as the month value, no validation error is displayed. The form is submitted, and the request is sent to the bank with an invalid expiration date.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy) or "Купить в кредит" (Buy on credit)
+3. Fill all fields with valid data, but enter `00` in the Month field
+4. Click "Продолжить" (Continue)
+
+## Actual result
+
+No validation error. The form is submitted.
+
+## Expected result
+
+A validation error should appear under the Month field: "Неверно указан срок действия карты" (Invalid card expiration date).
+
+---
+
+## Issue #10
+
+**Title:** Missing validation error for invalid data in input fields
+
+**Body:**
+
+## Description
+
+When submitting the form with certain types of invalid data in input fields (e.g., single character in card number, single digit in CVC), no validation error is displayed, and the form either submits or behaves incorrectly.
+
+## Steps to reproduce
+
+1. Open `http://localhost:8080/`
+2. Click "Купить" (Buy)
+3. Enter incomplete/invalid data in one of the fields (e.g., `4` in card number, `0` in CVC)
+4. Fill remaining fields with valid data
+5. Click "Продолжить" (Continue)
+
+## Actual result
+
+No validation error message appears under the field with invalid data.
+
+## Expected result
+
+A validation error "Неверный формат" (Invalid format) should appear under the field containing invalid data.

--- a/src/test/java/junit/extension/VideoAttachExtension.java
+++ b/src/test/java/junit/extension/VideoAttachExtension.java
@@ -1,0 +1,52 @@
+package junit.extension;
+
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+public class VideoAttachExtension implements TestWatcher {
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        try (var files = Files.list(Path.of("videos"))) {
+            files.filter(f -> f.toString().endsWith(".mp4"))
+                    .max(Comparator.comparingLong(f -> f.toFile().lastModified()))
+                    .ifPresent(f -> {
+                        try {
+                            Allure.addAttachment(
+                                    context.getDisplayName(),
+                                    "video/mp4",
+                                    Files.newInputStream(f),
+                                    ".mp4");
+                        } catch (IOException e) {
+                            throw new RuntimeException("Failed to attach video", e);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read videos directory", e);
+        }
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        try (var files = Files.list(Path.of("videos"))) {
+            files.filter(f -> f.toString().endsWith(".mp4"))
+                    .max(Comparator.comparingLong(f -> f.toFile().lastModified()))
+                    .ifPresent(f -> {
+                        try {
+                            Files.delete(f);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Failed to delete video", e);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read videos directory", e);
+        }
+    }
+
+}

--- a/src/test/java/junit/extension/VideoAttachExtension.java
+++ b/src/test/java/junit/extension/VideoAttachExtension.java
@@ -11,9 +11,12 @@ import java.util.Comparator;
 
 public class VideoAttachExtension implements TestWatcher {
 
+    private static final Path VIDEOS_DIR = Path.of("videos");
+
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
-        try (var files = Files.list(Path.of("videos"))) {
+        if (!Files.exists(VIDEOS_DIR)) return;
+        try (var files = Files.list(VIDEOS_DIR)) {
             files.filter(f -> f.toString().endsWith(".mp4"))
                     .max(Comparator.comparingLong(f -> f.toFile().lastModified()))
                     .ifPresent(f -> {
@@ -34,7 +37,8 @@ public class VideoAttachExtension implements TestWatcher {
 
     @Override
     public void testSuccessful(ExtensionContext context) {
-        try (var files = Files.list(Path.of("videos"))) {
+        if (!Files.exists(VIDEOS_DIR)) return;
+        try (var files = Files.list(VIDEOS_DIR)) {
             files.filter(f -> f.toString().endsWith(".mp4"))
                     .max(Comparator.comparingLong(f -> f.toFile().lastModified()))
                     .ifPresent(f -> {
@@ -48,5 +52,4 @@ public class VideoAttachExtension implements TestWatcher {
             throw new RuntimeException("Failed to read videos directory", e);
         }
     }
-
 }

--- a/src/test/java/test/BuyingTripApiTest.java
+++ b/src/test/java/test/BuyingTripApiTest.java
@@ -28,5 +28,4 @@ public class BuyingTripApiTest {
         int statusCode = ApiClient.getRequestStatusCode(invalidHolderCard, "/api/v1/credit");
         assertNotEquals(200, statusCode);
     }
-
 }

--- a/src/test/java/test/BuyingTripDbTest.java
+++ b/src/test/java/test/BuyingTripDbTest.java
@@ -2,21 +2,23 @@ package test;
 
 import com.codeborne.selenide.logevents.SelenideLogger;
 import data.Card;
-import utils.DataGenerator;
-import utils.DbClient;
 import io.qameta.allure.Description;
 import io.qameta.allure.selenide.AllureSelenide;
+import junit.extension.VideoAttachExtension;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import page.CreditPage;
 import page.PaymentPage;
 import page.StartPage;
+import utils.DataGenerator;
+import utils.DbClient;
 
 import java.sql.SQLException;
 
 import static com.codeborne.selenide.Selenide.open;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
+@ExtendWith(VideoAttachExtension.class)
 public class BuyingTripDbTest {
     Card validCard = DataGenerator.getValidCard();
     Card declinedCard = DataGenerator.getDeclinedCard();
@@ -108,5 +110,4 @@ public class BuyingTripDbTest {
         creditPage.shouldShowErrorNotification();
         assertEquals("0", DbClient.countRecords());
     }
-
 }

--- a/src/test/java/test/BuyingTripUiTest.java
+++ b/src/test/java/test/BuyingTripUiTest.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.logevents.SelenideLogger;
 import data.Card;
 import io.qameta.allure.Description;
 import io.qameta.allure.selenide.AllureSelenide;
+import junit.extension.VideoAttachExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import utils.DataGenerator;
 
 import org.junit.jupiter.api.*;
@@ -16,7 +18,7 @@ import page.StartPage;
 import static com.codeborne.selenide.Selenide.open;
 import static org.junit.jupiter.api.Assertions.*;
 
-
+@ExtendWith(VideoAttachExtension.class)
 public class BuyingTripUiTest {
 
     @BeforeEach
@@ -104,5 +106,4 @@ public class BuyingTripUiTest {
         creditPage.fillData(invalidExpDateCard);
         assertTrue(creditPage.isValidationErrorVisible(), "Expected validation error for expiration date exceeds 5 years on credit page");
     }
-
 }


### PR DESCRIPTION
## Summary

- Add Selenium Grid 4 Standalone (Chromium) to docker-compose for containerized browser testing
- Add `selenium/video` sidecar for session recording
- Create `VideoAttachExtension` (JUnit TestWatcher) — attaches video to Allure on failure, deletes on success
- Add `selenide.remote` system property — tests work both locally and through Grid
- noVNC live view available at http://localhost:7900
- Update README with Selenium Grid documentation

## Usage

```bash
# Local browser (default, no changes needed)
./gradlew test -Ddb.url=jdbc:mysql://localhost:3306/app

# Through Selenium Grid
./gradlew test -Ddb.url=jdbc:mysql://localhost:3306/app \
  -Dselenide.remote=http://localhost:4444/wd/hub \
  -Dsut.url=http://host.docker.internal:8080/
```

## Test plan

- [x] All 26 tests pass locally (6 expected SUT failures)
- [x] UI tests pass through Grid (same 6 SUT failures)
- [x] VideoAttachExtension guard works — no errors without videos directory
- [ ] Video recording on Linux/CI
- [ ] Verify Allure attachment with video