### PR TITLE
chore: rename project to alfabank-journey-of-the-day-autotests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <h1 align="center">🧪 Journey of the Day — Test Automation Framework</h1>
+  <h1 align="center">🧪 Journey of the Day — Automated Test Suite</h1>
   <p align="center">
     Multi-layer test automation for a tour-booking web application<br/>
-    <strong>UI · API · Database</strong> — all in one framework
+    <strong>UI · API · Database</strong> — all in one suite
   </p>
 </p>
 
@@ -20,7 +20,7 @@
 
 ## About
 
-**Journey of the Day** is a test automation framework for an [Alfa-Bank](https://alfabank.ru/) web service — a Spring Boot tour-booking application with integrated payment processing. The SUT offers two purchase flows — direct debit card payment and bank credit — both routed through a simulated payment gateway. This framework validates the entire vertical: from the browser UI through REST endpoints down to the database state.
+**Journey of the Day** is an automated test suite for an [Alfa-Bank](https://alfabank.ru/) web service — a Spring Boot tour-booking application with integrated payment processing. The SUT offers two purchase flows — direct debit card payment and bank credit — both routed through a simulated payment gateway. This suite validates the entire vertical: from the browser UI through REST endpoints down to the database state.
 
 The project was developed as a diploma capstone for [Netology's](https://netology.ru/) QA Automation program ([certificate](https://netology.ru/sharing/6f7576bbc619a45373ef783483cab60d?utm_source=social&utm_campaign=certificate_lms)). It demonstrates a production-grade approach to test architecture with clean separation of concerns, dual-database support, and containerized infrastructure.
 
@@ -36,7 +36,7 @@ The project was developed as a diploma capstone for [Netology's](https://netolog
 
 ## Application UI
 
-The SUT is a single-page tour-booking application. Below are the key screens that the test framework interacts with.
+The SUT is a single-page tour-booking application. Below are the key screens that the test suite interacts with.
 
 **Landing page** — the starting point with two purchase options:
 
@@ -73,7 +73,7 @@ The SUT is a single-page tour-booking application. Below are the key screens tha
   <img src="docs/architecture.png" alt="Architecture Diagram — C4 Container Level" width="800"/>
 </p>
 
-The framework tests three layers of the application stack:
+The suite tests three layers of the application stack:
 
 **Key design decisions:**
 
@@ -290,7 +290,7 @@ It listens on port **9999** and handles both `/payment` and `/credit` endpoints.
 
 ## Selenium Grid
 
-The framework supports remote browser execution via [Selenium Grid 4](https://www.selenium.dev/documentation/grid/) Standalone. When enabled, tests run inside a Docker container with Chromium — no local browser installation required.
+The suite supports remote browser execution via [Selenium Grid 4](https://www.selenium.dev/documentation/grid/) Standalone. When enabled, tests run inside a Docker container with Chromium — no local browser installation required.
 
 | Service | Port | Purpose |
 |:--------|:-----|:--------|
@@ -322,4 +322,4 @@ The report includes test execution details, step-by-step Selenide logs, and scre
 
 ## License
 
-This project is a demonstration/educational framework. Feel free to use it as a reference for your own test automation projects.
+This project is a demonstration/educational test suite. Feel free to use it as a reference for your own test automation projects.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ All UI and DB tests run against both **Payment** and **Credit** flows.
 **1. Clone the repository**
 
 ```bash
-git clone https://github.com/nelakov/demo-alfabank-test-framework.git
-cd demo-alfabank-test-framework
+git clone https://github.com/nelakov/alfabank-journey-of-the-day-autotests.git
+cd alfabank-journey-of-the-day-autotests
 ```
 
 **2. Start infrastructure**
@@ -202,7 +202,7 @@ The application will be available at `http://localhost:8080`.
 ## Project Structure
 
 ```
-demo-alfabank-test-framework/
+alfabank-journey-of-the-day-autotests/
 ├── artifacts/
 │   └── aqa-shop.jar              # SUT — Spring Boot application
 ├── gate-simulator/                # Payment gateway mock

--- a/docs/Report.md
+++ b/docs/Report.md
@@ -58,16 +58,16 @@ All scenarios from the [Test Automation Plan](Plan.md) have been executed.
 
 ### Found bugs
 
-1. [Spelling error in the name of the tour](https://github.com/nelakov/demo-alfabank-test-framework/issues/1)
-2. [When paying with an invalid card, error and success messages appear simultaneously](https://github.com/nelakov/demo-alfabank-test-framework/issues/2)
-3. [credit_id is not created in the DB in the order_entity table](https://github.com/nelakov/demo-alfabank-test-framework/issues/3)
-4. [Incorrect characters can be entered in the "Owner" field](https://github.com/nelakov/demo-alfabank-test-framework/issues/4)
-5. [You can enter Cyrillic characters in the "Owner" field](https://github.com/nelakov/demo-alfabank-test-framework/issues/5)
-6. [If the CVC/CVV field is not filled in, a warning appears under the Owner field](https://github.com/nelakov/demo-alfabank-test-framework/issues/6)
-7. [Incorrect status entry in the database and incorrect pop-up with transaction status](https://github.com/nelakov/demo-alfabank-test-framework/issues/7)
-8. [Invalid record of the transaction status in the database](https://github.com/nelakov/demo-alfabank-test-framework/issues/8)
-9. [Missing pop-up "Incorrect data entered"](https://github.com/nelakov/demo-alfabank-test-framework/issues/9)
-10. [There is no error message when entering incorrect data](https://github.com/nelakov/demo-alfabank-test-framework/issues/10)
+1. [Spelling error in the name of the tour](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/1)
+2. [When paying with an invalid card, error and success messages appear simultaneously](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/2)
+3. [credit_id is not created in the DB in the order_entity table](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/3)
+4. [Incorrect characters can be entered in the "Owner" field](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/4)
+5. [You can enter Cyrillic characters in the "Owner" field](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/5)
+6. [If the CVC/CVV field is not filled in, a warning appears under the Owner field](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/6)
+7. [Incorrect status entry in the database and incorrect pop-up with transaction status](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/7)
+8. [Invalid record of the transaction status in the database](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/8)
+9. [Missing pop-up "Incorrect data entered"](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/9)
+10. [There is no error message when entering incorrect data](https://github.com/nelakov/alfabank-journey-of-the-day-autotests/issues/10)
 
 ### Recommendations
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'demo-alfabank-test-framework'
+rootProject.name = 'alfabank-journey-of-the-day-autotests'
 


### PR DESCRIPTION
Renames the project: `demo-alfabank-test-framework` → `alfabank-journey-of-the-day-autotests`.

**Why**
- `demo-` was redundant — repo lives under `demo-projects/`.
- `-autotests` is truthful: single-SUT test suite, not reusable infrastructure.
- `journey-of-the-day` names the SUT, matching the README brand.

**Commits**
- `f2b90b4` slug rename — `rootProject.name`, README clone/cd/tree, `docs/Report.md` issue links.
- `191f055` README prose — 'framework' → 'test suite' (JUnit tech-stack row kept).

GitHub repo + local directory already renamed; old URLs auto-redirect.